### PR TITLE
fix compiler warning

### DIFF
--- a/Core/vsgio/vsgio.cpp
+++ b/Core/vsgio/vsgio.cpp
@@ -92,9 +92,9 @@ int main(int argc, char** argv)
 
         auto image = vsg::vec4Array2D::create(3, 3);
 
-        for(size_t i=0; i<image->width(); ++i)
+        for(uint32_t i=0; i<image->width(); ++i)
         {
-            for(size_t j=0; j<image->height(); ++j)
+            for(uint32_t j=0; j<image->height(); ++j)
             {
                 image->at(i, j) = vsg::vec4(static_cast<float>(i), static_cast<float>(j), static_cast<float>(i*j), 1.0f);
             }


### PR DESCRIPTION
as width() and height() return a uint32_t and at() expects 2x uint32_t a compiler warning about truncating a size_t value can be avoided at no cost.
Regards, Laurens.