### PR TITLE
added VulkanSceneGraph as a dependency submodule 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/VulkanSceneGraph"]
+	path = deps/VulkanSceneGraph
+	url = ../../vsg-dev/VulkanSceneGraph.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ if (VULKAN_SDK)
     set(ENV{VULKAN_SDK} ${VULKAN_SDK})
 endif()
 
-find_package(vsg REQUIRED)
-
+#find_package(vsg REQUIRED)
+add_subdirectory(deps)
 # find the optional vsgXchange that can be used for reading and range of image and 3d model formats and shader compilation
 find_package(vsgXchange QUIET)
 
@@ -30,9 +30,9 @@ find_package(vsgXchange QUIET)
 set(CMAKE_CXX_STANDARD 17)
 
 # add clobber build target to clear all the non git registered files/directories
-add_custom_target(clobber
-    COMMAND git clean -d -f -x
-)
+#add_custom_target(clobber
+#    COMMAND git clean -d -f -x
+#)
 
 # pure VSG examples
 add_subdirectory(Core)

--- a/Core/vsgallocator/CMakeLists.txt
+++ b/Core/vsgallocator/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES vsgallocator.cpp)
 
 add_executable(vsgallocator ${SOURCES})
 
-target_link_libraries(vsgallocator vsg::vsg)
+target_link_libraries(vsgallocator vsg)

--- a/Core/vsgarrays/CMakeLists.txt
+++ b/Core/vsgarrays/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES vsgarrays.cpp)
 
 add_executable(vsgarrays ${SOURCES})
 
-target_link_libraries(vsgarrays vsg::vsg)
+target_link_libraries(vsgarrays vsg)

--- a/Core/vsgc_interface/CMakeLists.txt
+++ b/Core/vsgc_interface/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES vsgc_interface.c)
 
 add_executable(vsgc_interface ${SOURCES})
 
-target_link_libraries(vsgc_interface vsg::vsg)
+target_link_libraries(vsgc_interface vsg)

--- a/Core/vsggroups/CMakeLists.txt
+++ b/Core/vsggroups/CMakeLists.txt
@@ -2,4 +2,4 @@ set(HEADERS SharedPtrNode.h)
 set(SOURCES SharedPtrNode.cpp vsggroups.cpp)
 
 add_executable(vsggroups ${HEADERS} ${SOURCES})
-target_link_libraries(vsggroups vsg::vsg)
+target_link_libraries(vsggroups vsg)

--- a/Core/vsgintrospection/CMakeLists.txt
+++ b/Core/vsgintrospection/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES vsgintrospection.cpp)
 
 add_executable(vsgintrospection ${SOURCES})
 
-target_link_libraries(vsgintrospection vsg::vsg)
+target_link_libraries(vsgintrospection vsg)

--- a/Core/vsgio/CMakeLists.txt
+++ b/Core/vsgio/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES vsgio.cpp)
 
 add_executable(vsgio ${SOURCES})
 
-target_link_libraries(vsgio vsg::vsg)
+target_link_libraries(vsgio vsg)

--- a/Core/vsgmaths/CMakeLists.txt
+++ b/Core/vsgmaths/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES vsgmaths.cpp)
 
 add_executable(vsgmaths ${SOURCES})
 
-target_link_libraries(vsgmaths vsg::vsg)
+target_link_libraries(vsgmaths vsg)

--- a/Core/vsgmemory/CMakeLists.txt
+++ b/Core/vsgmemory/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES vsgmemory.cpp)
 
 add_executable(vsgmemory ${SOURCES})
 
-target_link_libraries(vsgmemory vsg::vsg)
+target_link_libraries(vsgmemory vsg)

--- a/Core/vsgpointer/CMakeLists.txt
+++ b/Core/vsgpointer/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES vsgpointer.cpp)
 
 add_executable(vsgpointer ${SOURCES})
 
-target_link_libraries(vsgpointer vsg::vsg)
+target_link_libraries(vsgpointer vsg)

--- a/Core/vsgtypes/CMakeLists.txt
+++ b/Core/vsgtypes/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES vsgtypes.cpp)
 
 add_executable(vsgtypes ${SOURCES})
 
-target_link_libraries(vsgtypes vsg::vsg)
+target_link_libraries(vsgtypes vsg)

--- a/Core/vsgvalues/CMakeLists.txt
+++ b/Core/vsgvalues/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES vsgvalues.cpp)
 
 add_executable(vsgvalues ${SOURCES})
 
-target_link_libraries(vsgvalues vsg::vsg)
+target_link_libraries(vsgvalues vsg)

--- a/Core/vsgvisitor/CMakeLists.txt
+++ b/Core/vsgvisitor/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES vsgvisitor.cpp)
 
 add_executable(vsgvisitor ${SOURCES})
 
-target_link_libraries(vsgvisitor vsg::vsg)
+target_link_libraries(vsgvisitor vsg)

--- a/Desktop/vsgcompute/CMakeLists.txt
+++ b/Desktop/vsgcompute/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES vsgcompute.cpp)
 
 add_executable(vsgcompute ${SOURCES})
 
-target_link_libraries(vsgcompute vsg::vsg)
+target_link_libraries(vsgcompute vsg)

--- a/Desktop/vsgdraw/CMakeLists.txt
+++ b/Desktop/vsgdraw/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES vsgdraw.cpp)
 
 add_executable(vsgdraw ${SOURCES})
 
-target_link_libraries(vsgdraw vsg::vsg)
+target_link_libraries(vsgdraw vsg)

--- a/Desktop/vsginput/CMakeLists.txt
+++ b/Desktop/vsginput/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES vsginput.cpp Text.cpp Text.h)
 
 add_executable(vsginput ${SOURCES})
 
-target_link_libraries(vsginput vsg::vsg)
+target_link_libraries(vsginput vsg)

--- a/Desktop/vsgintersection/CMakeLists.txt
+++ b/Desktop/vsgintersection/CMakeLists.txt
@@ -6,7 +6,7 @@ set(SOURCES
 
 add_executable(vsgintersection ${SOURCES})
 
-target_link_libraries(vsgintersection vsg::vsg)
+target_link_libraries(vsgintersection vsg)
 
 if (vsgXchange_FOUND)
     target_compile_definitions(vsgintersection PRIVATE USE_VSGXCHANGE)

--- a/Desktop/vsgmultigpu/CMakeLists.txt
+++ b/Desktop/vsgmultigpu/CMakeLists.txt
@@ -7,4 +7,4 @@ add_executable(vsgmultigpu ${SOURCES})
 
 target_include_directories(vsgmultigpu PRIVATE ../vsgviewer)
 
-target_link_libraries(vsgmultigpu vsg::vsg)
+target_link_libraries(vsgmultigpu vsg)

--- a/Desktop/vsgraytracing/CMakeLists.txt
+++ b/Desktop/vsgraytracing/CMakeLists.txt
@@ -4,4 +4,4 @@ set(SOURCES
 
 add_executable(vsgraytracing ${SOURCES})
 
-target_link_libraries(vsgraytracing vsg::vsg)
+target_link_libraries(vsgraytracing vsg)

--- a/Desktop/vsgsubpass/CMakeLists.txt
+++ b/Desktop/vsgsubpass/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SOURCES vsgsubpass.cpp)
 
 add_executable(vsgsubpass ${SOURCES})
 
-target_link_libraries(vsgsubpass vsg::vsg)
+target_link_libraries(vsgsubpass vsg)

--- a/Desktop/vsgviewer/CMakeLists.txt
+++ b/Desktop/vsgviewer/CMakeLists.txt
@@ -5,7 +5,7 @@ set(SOURCES
 
 add_executable(vsgviewer ${SOURCES})
 
-target_link_libraries(vsgviewer vsg::vsg)
+target_link_libraries(vsgviewer vsg)
 
 if (vsgXchange_FOUND)
     target_compile_definitions(vsgviewer PRIVATE USE_VSGXCHANGE)

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(VulkanSceneGraph)


### PR DESCRIPTION
VulkanSceneGraph is added as a sub-module of vsgExamples, makes it much easier to develop .
all you need is :
- clone vsgExamples
- git submodule update --init
- build examples