### PR TITLE
Moore/multisample

### DIFF
--- a/Desktop/vsgraytracing/vsgraytracing.cpp
+++ b/Desktop/vsgraytracing/vsgraytracing.cpp
@@ -1,6 +1,7 @@
 #include <vsg/all.h>
 #include <iostream>
 
+#if 0
 vsg::ImageData createImageView(vsg::Context& context, const VkImageCreateInfo& imageCreateInfo, VkImageAspectFlags aspectFlags, VkImageLayout targetImageLayout)
 {
     vsg::Device* device = context.device;
@@ -24,6 +25,7 @@ vsg::ImageData createImageView(vsg::Context& context, const VkImageCreateInfo& i
 
     return vsg::ImageData(nullptr, imageview, targetImageLayout);
 }
+#endif
 
 struct RayTracingUniform
 {
@@ -210,7 +212,9 @@ int main(int argc, char** argv)
     // for convenience create a compile context for creating our storage image
     vsg::CompileTraversal compile(window);
 
-    vsg::ImageData storageImageData = createImageView(compile.context, storageImageCreateInfo, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
+    vsg::ImageData storageImageData{nullptr,
+                                    createImageView(compile.context, storageImageCreateInfo, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL),
+                                    VK_IMAGE_LAYOUT_GENERAL};
 
 
     auto raytracingUniformValues = new RayTracingUniformValue();

--- a/Desktop/vsgrendertotexture/vsgrendertotexture.cpp
+++ b/Desktop/vsgrendertotexture/vsgrendertotexture.cpp
@@ -34,30 +34,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 // dependencies of the offscreen RenderPass / RenderGraph need to be
 // set up so that the second RenderGraph can sample the output.
 
-// Create an image. This should probably be in VSG.
-vsg::ImageData createImageView(vsg::Context& context, const VkImageCreateInfo& imageCreateInfo,
-                               VkImageAspectFlags aspectFlags, VkImageLayout targetImageLayout)
-{
-    vsg::Device* device = context.device;
-
-    auto image = vsg::Image::create(device, imageCreateInfo);
-
-    // allocate memory with out export memory info extension
-    auto[deviceMemory, offset] = context.deviceMemoryBufferPools->reserveMemory(image->getMemoryRequirements(), VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-
-    if (!deviceMemory)
-    {
-        std::cout << "Warning: Failed allocate memory to reserve slot" << std::endl;
-        return vsg::ImageData();
-    }
-
-    image->bind(deviceMemory, offset);
-
-    auto imageview = vsg::ImageView::create(device, image, VK_IMAGE_VIEW_TYPE_2D, imageCreateInfo.format, aspectFlags);
-
-    return vsg::ImageData(nullptr, imageview, targetImageLayout);
-}
-
 // Rendergraph for rendering to image
 
 vsg::ref_ptr<vsg::RenderGraph> createOffscreenRendergraph(vsg::Device* device, vsg::Context& context, vsg::Camera* camera,
@@ -82,9 +58,11 @@ vsg::ref_ptr<vsg::RenderGraph> createOffscreenRendergraph(vsg::Device* device, v
     colorImageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     colorImageCreateInfo.queueFamilyIndexCount = 0;
     colorImageCreateInfo.pNext = nullptr;
-    colorImage = createImageView(context, colorImageCreateInfo,
-                                 VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    auto colorImageView = createImageView(context, colorImageCreateInfo,
+                                          VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     // Sampler for accessing attachment as a texture
+    colorImage._imageView = colorImageView;
+    colorImage._imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     auto colorSampler = vsg::Sampler::create();
     VkSamplerCreateInfo& samplerInfo = colorSampler->info();
     samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
@@ -119,9 +97,11 @@ vsg::ref_ptr<vsg::RenderGraph> createOffscreenRendergraph(vsg::Device* device, v
     depthImageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     depthImageCreateInfo.pNext = nullptr;
     // XXX Does layout matter?
-    depthImage = createImageView(context, depthImageCreateInfo,
-                                 VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT,
-                                 VK_IMAGE_LAYOUT_GENERAL);
+    depthImage._sampler = nullptr;
+    depthImage._imageView = createImageView(context, depthImageCreateInfo,
+                                            VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT,
+                                            VK_IMAGE_LAYOUT_GENERAL);
+    depthImage._imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
     // attachment descriptions
     vsg::RenderPass::Attachments attachments(2);
@@ -195,15 +175,14 @@ vsg::ref_ptr<vsg::RenderGraph> createOffscreenRendergraph(vsg::Device* device, v
     fbufCreateInfo.layers = 1;
     auto fbuf = vsg::Framebuffer::create(device, fbufCreateInfo);
     auto rendergraph = vsg::RenderGraph::create();
-    auto frameAssembly = vsg::SingleFrameAssembly::create(fbuf, renderPass, extent);
+    vsg::FrameAssembly::ClearValues clearValues(2);
+    clearValues[0].color = { { 0.4f, 0.2f, 0.2f, 1.0f } };
+    clearValues[1].depthStencil = { 1.0f, 0 };
+    auto frameAssembly = vsg::SingleFrameAssembly::create(fbuf, renderPass, clearValues, extent);
     rendergraph->camera = camera;
     rendergraph->renderArea.offset = VkOffset2D{0, 0};
     rendergraph->renderArea.extent = extent;
     rendergraph->frameAssembly = frameAssembly;
-    VkClearValue clearValues[2];
-    clearValues[0].color = { { 0.4f, 0.2f, 0.2f, 1.0f } };
-    clearValues[1].depthStencil = { 1.0f, 0 };
-    rendergraph->clearValues.insert(rendergraph->clearValues.begin(), &clearValues[0], &clearValues[2]);
     return rendergraph;
 }
 

--- a/Desktop/vsgrendertotexture/vsgrendertotexture.cpp
+++ b/Desktop/vsgrendertotexture/vsgrendertotexture.cpp
@@ -194,13 +194,12 @@ vsg::ref_ptr<vsg::RenderGraph> createOffscreenRendergraph(vsg::Device* device, v
     fbufCreateInfo.height = extent.height;
     fbufCreateInfo.layers = 1;
     auto fbuf = vsg::Framebuffer::create(device, fbufCreateInfo);
-
     auto rendergraph = vsg::RenderGraph::create();
+    auto frameAssembly = vsg::SingleFrameAssembly::create(fbuf, renderPass, extent);
     rendergraph->camera = camera;
     rendergraph->renderArea.offset = VkOffset2D{0, 0};
     rendergraph->renderArea.extent = extent;
-    rendergraph->renderPass = renderPass;
-    rendergraph->framebuffer = fbuf;
+    rendergraph->frameAssembly = frameAssembly;
     VkClearValue clearValues[2];
     clearValues[0].color = { { 0.4f, 0.2f, 0.2f, 1.0f } };
     clearValues[1].depthStencil = { 1.0f, 0 };

--- a/Desktop/vsgrendertotexture/vsgrendertotexture.cpp
+++ b/Desktop/vsgrendertotexture/vsgrendertotexture.cpp
@@ -385,8 +385,9 @@ vsg::ref_ptr<vsg::Camera> createCameraForScene(vsg::Node* scenegraph, const VkEx
     auto lookAt = vsg::LookAt::create(centre+vsg::dvec3(0.0, -radius*3.5, 0.0),
                                       centre, vsg::dvec3(0.0, 0.0, 1.0));
 
-    auto perspective = vsg::Perspective::create(30.0, static_cast<double>(extent.width) / static_cast<double>(extent.height),
-                                                nearFarRatio*radius, radius * 4.5);
+    auto perspective = vsg::Perspective::create(30.0,
+                                           static_cast<double>(extent.width) / static_cast<double>(extent.height),
+                                           radius / 4.5, radius / (4.5 * nearFarRatio));
 
     return vsg::Camera::create(perspective, lookAt, vsg::ViewportState::create(extent));
 }


### PR DESCRIPTION
vsgviewer example that takes a --samples argument. It uses the functionality in vsg-dev/VulkanSceneGraph#179 to create a multisampled frame buffer. It then traverses the scene graph to install the correct multisampling graphics state.