### PR TITLE
Fix bug on Windows defining a class outside VSG library with VSG_DECLSPEC

### DIFF
--- a/examples/viewer/vsganaglyphicstereo/vsganaglyphicstereo.cpp
+++ b/examples/viewer/vsganaglyphicstereo/vsganaglyphicstereo.cpp
@@ -9,7 +9,7 @@
 
 namespace vsg
 {
-    class VSG_DECLSPEC PerViewGraphicsPipelineState : public Inherit<GraphicsPipelineState, PerViewGraphicsPipelineState>
+    class PerViewGraphicsPipelineState : public Inherit<GraphicsPipelineState, PerViewGraphicsPipelineState>
     {
     public:
         PerViewGraphicsPipelineState() {}


### PR DESCRIPTION
I noticed this bug when compiling vsgExamples on Windows with gcc.