### PR TITLE
Install only the files from the local directory 'data', not the directory itself

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
 endif()
 
 # install data
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data DESTINATION share/vsgExamples)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data/ DESTINATION share/vsgExamples)
 
 # pure VSG examples
 add_subdirectory(examples/core)


### PR DESCRIPTION
This commit fixes a problem that was discovered when packaging vsgExample in the openSUSE distribution.