### PR TITLE
Add keyPress.keyBase and keyRelease.keyBase to display as character.

### DIFF
--- a/examples/ui/vsginput/vsginput.cpp
+++ b/examples/ui/vsginput/vsginput.cpp
@@ -38,12 +38,12 @@ public:
 
     void apply(vsg::KeyPressEvent& keyPress) override
     {
-        assign(*keyboard_text, vsg::make_string(keyPress.className(), ", keyBase=", keyPress.keyBase, ", keyModified=", keyPress.keyModified, " ", char(keyPress.keyModified)));
+        assign(*keyboard_text, vsg::make_string(keyPress.className(), ", keyBase=", keyPress.keyBase, " ", char(keyPress.keyBase), ", keyModified=", keyPress.keyModified, " ", char(keyPress.keyModified)));
     }
 
     void apply(vsg::KeyReleaseEvent& keyRelease) override
     {
-        assign(*keyboard_text, vsg::make_string(keyRelease.className(), ", keyBase=", keyRelease.keyBase, ", keyModified=", keyRelease.keyModified, " ", char(keyRelease.keyModified)));
+        assign(*keyboard_text, vsg::make_string(keyRelease.className(), ", keyBase=", keyRelease.keyBase, " ", char(keyRelease.keyBase), ", keyModified=", keyRelease.keyModified, " ", char(keyRelease.keyModified)));
     }
 
     void apply(vsg::MoveEvent& moveEvent) override


### PR DESCRIPTION
Feature Add.

1) Currently, vsginput does not display the keyPress.keyBase as a character, while it does display keyPress.keyModified as a character.
2) Currently, vsginput does not display the keyRelease.keyBase as a character, while it does display keyRelease.keyModified as a character.

This PR allows for easier debugging of keymap issues in the future, as I am doing so now.
