### PR TITLE
Fix bug in two-sided lighting

### DIFF
--- a/data/shaders/standard_phong.frag
+++ b/data/shaders/standard_phong.frag
@@ -52,6 +52,7 @@ layout(location = 0) out vec4 outColor;
 // or from the interpolated mesh normal and tangent attributes.
 vec3 getNormal()
 {
+    vec3 result;
 #ifdef VSG_NORMAL_MAP
     // Perturb normal, see http://www.thetenthplanet.de/archives/1180
     vec3 tangentNormal = texture(normalMap, texCoord0).xyz * 2.0 - 1.0;
@@ -68,10 +69,15 @@ vec3 getNormal()
     vec3 B = -normalize(cross(N, T));
     mat3 TBN = mat3(T, B, N);
 
-    return normalize(TBN * tangentNormal);
+    result = normalize(TBN * tangentNormal);
 #else
-    return normalize(normalDir);
+    result = normalize(normalDir);
 #endif
+#ifdef VSG_TWO_SIDED_LIGHTING
+    if (!gl_FrontFacing)
+        result = -result;
+#endif
+
 }
 
 vec3 computeLighting(vec3 ambientColor, vec3 diffuseColor, vec3 specularColor, vec3 emissiveColor, float shininess, float ambientOcclusion, vec3 ld, vec3 nd, vec3 vd)
@@ -165,13 +171,6 @@ void main()
             vec3 direction = -lightData.values[index++].xyz;
 
             float unclamped_LdotN = dot(direction, nd);
-            #ifdef VSG_TWO_SIDED_LIGHTING
-            if (unclamped_LdotN < 0.0)
-            {
-                nd = -nd;
-                unclamped_LdotN = -unclamped_LdotN;
-            }
-            #endif
 
             float diff = max(unclamped_LdotN, 0.0);
             color.rgb += (diffuseColor.rgb * lightColor.rgb) * (diff * lightColor.a);
@@ -197,13 +196,6 @@ void main()
             float scale = lightColor.a / distance2;
 
             float unclamped_LdotN = dot(direction, nd);
-            #ifdef VSG_TWO_SIDED_LIGHTING
-            if (unclamped_LdotN < 0.0)
-            {
-                nd = -nd;
-                unclamped_LdotN = -unclamped_LdotN;
-            }
-            #endif
 
             float diff = scale * max(unclamped_LdotN, 0.0);
 
@@ -233,13 +225,6 @@ void main()
             float scale = (lightColor.a  * smoothstep(lightDirection_cosOuterAngle.w, position_cosInnerAngle.w, dot_lightdirection)) / distance2;
 
             float unclamped_LdotN = dot(direction, nd);
-            #ifdef VSG_TWO_SIDED_LIGHTING
-            if (unclamped_LdotN < 0.0)
-            {
-                nd = -nd;
-                unclamped_LdotN = -unclamped_LdotN;
-            }
-            #endif
 
             float diff = scale * max(unclamped_LdotN, 0.0);
             color.rgb += (diffuseColor.rgb * lightColor.rgb) * diff;


### PR DESCRIPTION
The fragment shaders need to use gl_FrontFacing to determine whether or not to reverse the surface normal. Otherwise, surfaces that are facing away from a light are illuminated by it.

This is a very lame pull request because I haven't actually tested this with vsgExamples. I don't know the incantation to regenerate the .spv files in the shaders directory, and I don't have the time to code up a shader set to use in a custom test. I originally copied standard_pbr.frag into vsgCs and fixed the bug there, but I can't just copy that shader back for a test case because various things have changed. Here are before-and-after screenshots from vsgCs (it's supposed to be night):

bad lighting:
![bad-hawaii](https://user-images.githubusercontent.com/133121/213209315-9c9ba52a-8d85-42a9-9fa7-9a4f63276d5f.png)

good lighting:
![good-hawaii](https://user-images.githubusercontent.com/133121/213209475-38613530-81a2-4f4f-8868-438059335627.png)
