### PR TITLE
implemented minimal example to reproduce the std::type_info().hash_code() issue with clang/libc++ on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,4 +84,6 @@ add_subdirectory(examples/platform)
 add_subdirectory(examples/utils)
 add_subdirectory(examples/volume)
 
+add_subdirectory(examples/bugs_repro)
+
 vsg_add_feature_summary()

--- a/examples/bugs_repro/CMakeLists.txt
+++ b/examples/bugs_repro/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(clang_typeid)

--- a/examples/bugs_repro/clang_typeid/CMakeLists.txt
+++ b/examples/bugs_repro/clang_typeid/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(DYLIB_SOURCES clang_typeid_dylib.cpp clang_typeid_dylib.h)
+add_library(clang_typeid_dylib SHARED ${DYLIB_SOURCES})
+target_link_libraries(clang_typeid_dylib vsg::vsg)
+install(TARGETS clang_typeid_dylib RUNTIME DESTINATION bin)
+
+set(SOURCES clang_typeid.cpp)
+add_executable(clang_typeid ${SOURCES})
+target_link_libraries(clang_typeid vsg::vsg clang_typeid_dylib)
+install(TARGETS clang_typeid RUNTIME DESTINATION bin)
+

--- a/examples/bugs_repro/clang_typeid/clang_typeid.cpp
+++ b/examples/bugs_repro/clang_typeid/clang_typeid.cpp
@@ -1,0 +1,16 @@
+#include <cstdlib>
+#include <iostream>
+#include "clang_typeid_dylib.h"
+
+int main(int argc, char** argv)
+{
+    auto local = vsg::MatrixTransform::create();
+    auto dylib = create_object_in_dylib();
+
+    std::cout << "Local: type name: " << local->type_info().name() << ", type hash: " << local->type_info().hash_code() << std::endl;
+    std::cout << "Dylib: type name: " << dylib->type_info().name() << ", type hash: " << dylib->type_info().hash_code() << std::endl;
+
+    std::cout << (dylib->is_compatible(local->type_info()) ? "types are compatible" : "types are not compatible") << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/examples/bugs_repro/clang_typeid/clang_typeid_dylib.cpp
+++ b/examples/bugs_repro/clang_typeid/clang_typeid_dylib.cpp
@@ -1,0 +1,7 @@
+#include "clang_typeid_dylib.h"
+
+vsg::ref_ptr<vsg::Object> create_object_in_dylib()
+{
+    auto factory = vsg::ObjectFactory::instance();
+    return factory->create("vsg::MatrixTransform");
+}

--- a/examples/bugs_repro/clang_typeid/clang_typeid_dylib.h
+++ b/examples/bugs_repro/clang_typeid/clang_typeid_dylib.h
@@ -1,0 +1,3 @@
+#include <vsg/all.h>
+
+vsg::ref_ptr<vsg::Object> create_object_in_dylib();


### PR DESCRIPTION
…