### PR TITLE
[FIXED] VSG_GREYSCALE_DIFFUSE_MAP typo

### DIFF
--- a/data/shaders/standard_flat_shaded.frag
+++ b/data/shaders/standard_flat_shaded.frag
@@ -1,6 +1,6 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
-#pragma import_defines (VSG_POINT_SPRITE, VSG_DIFFUSE_MAP, VSG_GREYSACLE_DIFFUSE_MAP)
+#pragma import_defines (VSG_POINT_SPRITE, VSG_DIFFUSE_MAP, VSG_GREYSCALE_DIFFUSE_MAP)
 
 #ifdef VSG_DIFFUSE_MAP
 layout(binding = 0) uniform sampler2D diffuseMap;
@@ -34,7 +34,7 @@ void main()
     vec4 diffuseColor = vertexColor * material.diffuseColor;
 
 #ifdef VSG_DIFFUSE_MAP
-    #ifdef VSG_GREYSACLE_DIFFUSE_MAP
+    #ifdef VSG_GREYSCALE_DIFFUSE_MAP
         float v = texture(diffuseMap, texCoord0.st).s;
         diffuseColor *= vec4(v, v, v, 1.0);
     #else

--- a/data/shaders/standard_pbr.frag
+++ b/data/shaders/standard_pbr.frag
@@ -1,6 +1,6 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
-#pragma import_defines (VSG_DIFFUSE_MAP, VSG_GREYSACLE_DIFFUSE_MAP, VSG_EMISSIVE_MAP, VSG_LIGHTMAP_MAP, VSG_NORMAL_MAP, VSG_METALLROUGHNESS_MAP, VSG_SPECULAR_MAP, VSG_TWO_SIDED_LIGHTING, VSG_WORKFLOW_SPECGLOSS)
+#pragma import_defines (VSG_DIFFUSE_MAP, VSG_GREYSCALE_DIFFUSE_MAP, VSG_EMISSIVE_MAP, VSG_LIGHTMAP_MAP, VSG_NORMAL_MAP, VSG_METALLROUGHNESS_MAP, VSG_SPECULAR_MAP, VSG_TWO_SIDED_LIGHTING, VSG_WORKFLOW_SPECGLOSS)
 
 const float PI = 3.14159265359;
 const float RECIPROCAL_PI = 0.31830988618;
@@ -312,7 +312,7 @@ void main()
     vec3 f0 = vec3(0.04);
 
 #ifdef VSG_DIFFUSE_MAP
-    #ifdef VSG_GREYSACLE_DIFFUSE_MAP
+    #ifdef VSG_GREYSCALE_DIFFUSE_MAP
         float v = texture(diffuseMap, texCoord0.st).s * pbr.baseColorFactor;
         baseColor = vertexColor * vec4(v, v, v, 1.0);
     #else

--- a/data/shaders/standard_phong.frag
+++ b/data/shaders/standard_phong.frag
@@ -1,6 +1,6 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
-#pragma import_defines (VSG_POINT_SPRITE, VSG_DIFFUSE_MAP, VSG_GREYSACLE_DIFFUSE_MAP, VSG_EMISSIVE_MAP, VSG_LIGHTMAP_MAP, VSG_NORMAL_MAP, VSG_SPECULAR_MAP, VSG_TWO_SIDED_LIGHTING)
+#pragma import_defines (VSG_POINT_SPRITE, VSG_DIFFUSE_MAP, VSG_GREYSCALE_DIFFUSE_MAP, VSG_EMISSIVE_MAP, VSG_LIGHTMAP_MAP, VSG_NORMAL_MAP, VSG_SPECULAR_MAP, VSG_TWO_SIDED_LIGHTING)
 
 #ifdef VSG_DIFFUSE_MAP
 layout(set = 0, binding = 0) uniform sampler2D diffuseMap;
@@ -108,7 +108,7 @@ void main()
 
     vec4 diffuseColor = vertexColor * material.diffuseColor;
 #ifdef VSG_DIFFUSE_MAP
-    #ifdef VSG_GREYSACLE_DIFFUSE_MAP
+    #ifdef VSG_GREYSCALE_DIFFUSE_MAP
         float v = texture(diffuseMap, texCoord0.st).s;
         diffuseColor *= vec4(v, v, v, 1.0);
     #else

--- a/examples/utils/vsgshaderset/flat.cpp
+++ b/examples/utils/vsgshaderset/flat.cpp
@@ -53,7 +53,7 @@ vsg::ref_ptr<vsg::ShaderSet> flat_ShaderSet(vsg::ref_ptr<const vsg::Options> opt
 
     shaderSet->addPushConstantRange("pc", "", VK_SHADER_STAGE_VERTEX_BIT, 0, 128);
 
-    shaderSet->optionalDefines = {"VSG_POINT_SPRITE", "VSG_GREYSACLE_DIFFUSE_MAP"};
+    shaderSet->optionalDefines = {"VSG_POINT_SPRITE", "VSG_GREYSCALE_DIFFUSE_MAP"};
 
     shaderSet->definesArrayStates.push_back(vsg::DefinesArrayState{{"VSG_INSTANCE_POSITIONS", "VSG_DISPLACEMENT_MAP"}, vsg::PositionAndDisplacementMapArrayState::create()});
     shaderSet->definesArrayStates.push_back(vsg::DefinesArrayState{{"VSG_INSTANCE_POSITIONS"}, vsg::PositionArrayState::create()});

--- a/examples/utils/vsgshaderset/pbr.cpp
+++ b/examples/utils/vsgshaderset/pbr.cpp
@@ -58,7 +58,7 @@ vsg::ref_ptr<vsg::ShaderSet> pbr_ShaderSet(vsg::ref_ptr<const vsg::Options> opti
     shaderSet->addUniformBinding("lightData", "", 1, 0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, vsg::vec4Array::create(64));
 
     // additional defines
-    shaderSet->optionalDefines = {"VSG_GREYSACLE_DIFFUSE_MAP", "VSG_TWO_SIDED_LIGHTING", "VSG_WORKFLOW_SPECGLOSS"};
+    shaderSet->optionalDefines = {"VSG_GREYSCALE_DIFFUSE_MAP", "VSG_TWO_SIDED_LIGHTING", "VSG_WORKFLOW_SPECGLOSS"};
 
     shaderSet->addPushConstantRange("pc", "", VK_SHADER_STAGE_VERTEX_BIT, 0, 128);
 

--- a/examples/utils/vsgshaderset/phong.cpp
+++ b/examples/utils/vsgshaderset/phong.cpp
@@ -57,7 +57,7 @@ vsg::ref_ptr<vsg::ShaderSet> phong_ShaderSet(vsg::ref_ptr<const vsg::Options> op
 
     shaderSet->addPushConstantRange("pc", "", VK_SHADER_STAGE_VERTEX_BIT, 0, 128);
 
-    shaderSet->optionalDefines = {"VSG_GREYSACLE_DIFFUSE_MAP", "VSG_TWO_SIDED_LIGHTING", "VSG_POINT_SPRITE"};
+    shaderSet->optionalDefines = {"VSG_GREYSCALE_DIFFUSE_MAP", "VSG_TWO_SIDED_LIGHTING", "VSG_POINT_SPRITE"};
 
     shaderSet->definesArrayStates.push_back(vsg::DefinesArrayState{{"VSG_INSTANCE_POSITIONS", "VSG_DISPLACEMENT_MAP"}, vsg::PositionAndDisplacementMapArrayState::create()});
     shaderSet->definesArrayStates.push_back(vsg::DefinesArrayState{{"VSG_INSTANCE_POSITIONS"}, vsg::PositionArrayState::create()});

--- a/examples/utils/vsgshaderset/vsgshaderset.cpp
+++ b/examples/utils/vsgshaderset/vsgshaderset.cpp
@@ -85,7 +85,7 @@ void print(const vsg::ShaderSet& shaderSet, std::ostream& out)
     out<<"variants.size() = "<<shaderSet.variants.size()<<std::endl;
     for(auto& [shaderCompileSettings, shaderStages] : shaderSet.variants)
     {
-        out<<"  Varient {"<<std::endl;
+        out<<"  Variant {"<<std::endl;
 
         out<<"    shaderCompileSettings = "<<shaderCompileSettings<<" : defines ";
         for(auto& define : shaderCompileSettings->defines) out<<define<<" ";
@@ -140,7 +140,7 @@ int main(int argc, char** argv)
     // set up defaults and read command line arguments to override them
     vsg::CommandLine arguments(&argc, argv);
 
-    // read any command line options that the ReaderWrite support
+    // read any command line options that the ReaderWriters support
     arguments.read(options);
     if (argc <= 1) return 0;
 
@@ -192,7 +192,7 @@ int main(int argc, char** argv)
     std::string str;
     while(arguments.read({"-v", "--variant"}, str))
     {
-        std::cout<<"varient : "<<str<<std::endl;
+        std::cout<<"variant : "<<str<<std::endl;
         auto scs = vsg::ShaderCompileSettings::create();
 
         std::cout<<"   ";
@@ -220,7 +220,7 @@ int main(int argc, char** argv)
         std::cout<<std::endl;
     }
 
-    // load remain command line parameters as models to help fill out the required ShaderSet variants
+    // load remaining command line parameters as models to help fill out the required ShaderSet variants
     for(int i = 1; i<argc; ++i)
     {
         vsg::Path filename(argv[i]);
@@ -239,7 +239,7 @@ int main(int argc, char** argv)
         std::cout<<"   "<<define<<std::endl;
     }
 
-    // keep track of the all the ShaderStages and share any that are the same
+    // keep track of all the ShaderStages and share any that are the same
     std::vector<vsg::ref_ptr<vsg::ShaderStage>> existing_stages;
 
     auto shaderCompiler = vsg::ShaderCompiler::create();


### PR DESCRIPTION
Fixed typo in VSG_GREYSCALE_DIFFUSE_MAP ShaderSet define. Matching changes would be needed in `vsg/utils/Builder.cpp` and shader blobs included by `vsg/utils/ShaderSet.cpp` (how to re-generate them?).