### PR TITLE
Add Doxygen html directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ CMakeDoxygenDefaults.cmake
 Doxyfile.docs
 Doxyfile.docs-vsgExamples
 
+html/
 
 # Compiled Object files
 *.slo


### PR DESCRIPTION
It's already there for the main repo, but not for the ancillary ones.