### PR TITLE
Fix alpha test for standard PBR shader

### DIFF
--- a/data/shaders/standard_pbr.frag
+++ b/data/shaders/standard_pbr.frag
@@ -336,7 +336,7 @@ void main()
 #endif
 
 #ifdef VSG_ALPHA_TEST
-    if (material.alphaMask == 1.0f && diffuseColor.a < material.alphaMaskCutoff) discard;
+    if (pbr.alphaMask == 1.0f && baseColor.a < pbr.alphaMaskCutoff) discard;
 #endif
 
 #ifdef VSG_WORKFLOW_SPECGLOSS


### PR DESCRIPTION
It looks like the existing line was copied and pasted from the Phong shader, but the variables don't match. Phong's `material`'s equivalent is called `pbr` in the PBR shader, and while `diffuseColor` is a real variable in the PBR shader, it's not been initialised when this line runs, so `baseColor` should be used instead.