### PR TITLE
Make gamma correction consistent between shader types

### DIFF
--- a/data/shaders/custom_pbr.frag
+++ b/data/shaders/custom_pbr.frag
@@ -559,5 +559,5 @@ void main()
         }
     }
 
-    outColor = LINEARtoSRGB(vec4(color, baseColor.a)) ;
+    outColor = vec4(color, baseColor.a);
 }

--- a/data/shaders/standard_flat_shaded.frag
+++ b/data/shaders/standard_flat_shaded.frag
@@ -27,6 +27,12 @@ layout(location = 3) in vec2 texCoord0;
 
 layout(location = 0) out vec4 outColor;
 
+vec4 SRGBtoLINEAR(vec4 srgbIn)
+{
+    vec3 linOut = pow(srgbIn.xyz, vec3(2.2));
+    return vec4(linOut,srgbIn.w);
+}
+
 void main()
 {
 #ifdef VSG_POINT_SPRITE
@@ -40,7 +46,7 @@ void main()
         float v = texture(diffuseMap, texCoord0.st).s;
         diffuseColor *= vec4(v, v, v, 1.0);
     #else
-        diffuseColor *= texture(diffuseMap, texCoord0.st);
+        diffuseColor *= SRGBtoLINEAR(texture(diffuseMap, texCoord0.st));
     #endif
 #endif
 

--- a/data/shaders/standard_pbr.frag
+++ b/data/shaders/standard_pbr.frag
@@ -541,5 +541,5 @@ void main()
         }
     }
 
-    outColor = LINEARtoSRGB(vec4(color, baseColor.a));
+    outColor = vec4(color, baseColor.a);
 }

--- a/data/shaders/standard_phong.frag
+++ b/data/shaders/standard_phong.frag
@@ -57,6 +57,12 @@ layout(location = 5) in vec3 viewDir;
 
 layout(location = 0) out vec4 outColor;
 
+vec4 SRGBtoLINEAR(vec4 srgbIn)
+{
+    vec3 linOut = pow(srgbIn.xyz, vec3(2.2));
+    return vec4(linOut,srgbIn.w);
+}
+
 // include the calculateShadowCoverageForDirectionalLight(..) implementation
 #include "shadows.glsl"
 
@@ -127,7 +133,7 @@ void main()
         float v = texture(diffuseMap, texCoord0.st).s;
         diffuseColor *= vec4(v, v, v, 1.0);
     #else
-        diffuseColor *= texture(diffuseMap, texCoord0.st);
+        diffuseColor *= SRGBtoLINEAR(texture(diffuseMap, texCoord0.st));
     #endif
 #endif
 
@@ -142,7 +148,7 @@ void main()
 #endif
 
 #ifdef VSG_EMISSIVE_MAP
-    emissiveColor *= texture(emissiveMap, texCoord0.st);
+    emissiveColor *= SRGBtoLINEAR(texture(emissiveMap, texCoord0.st));
 #endif
 
 #ifdef VSG_LIGHTMAP_MAP
@@ -150,7 +156,7 @@ void main()
 #endif
 
 #ifdef VSG_SPECULAR_MAP
-    specularColor *= texture(specularMap, texCoord0.st);
+    specularColor *= SRGBtoLINEAR(texture(specularMap, texCoord0.st));
 #endif
 
     vec3 nd = getNormal();


### PR DESCRIPTION
As this gets rid of the final manual to-sRGB conversion from the PBR shader, it's best paired with https://github.com/vsg-dev/VulkanSceneGraph/commit/9ed19d608191f62d5ab97af831d1fc77879cbfc7 so an automatic conversion happens.

This doesn't tackle the issue of sampling (e.g. trilinear, anisotropic) giving incorrect results due to happening to an sRGB image while the hardware's been told it's a linear colour one, but is a useful step.