### PR TITLE
vsgcameras demo of viewport partially off screen

### DIFF
--- a/examples/app/vsgcameras/vsgcameras.cpp
+++ b/examples/app/vsgcameras/vsgcameras.cpp
@@ -286,9 +286,11 @@ int main(int argc, char** argv)
     for (auto& [nodePath, camera] : scene_cameras)
     {
         // create a RenderGraph to add a secondary vsg::View on the top right part of the window.
-        auto projectionMatrix = camera->projectionMatrix;
+        auto projectionMatrix = vsg::Perspective::create(30.0, static_cast<double>(secondary_width) / static_cast<double>(secondary_height),
+                                                    nearFarRatio * radius, radius * 4.5);
         auto viewMatrix = vsg::TrackingViewMatrix::create(nodePath);
-        auto viewportState = vsg::ViewportState::create(x, y, secondary_width, secondary_height);
+        auto viewportState = vsg::ViewportState::create(x + 150, y, secondary_width, secondary_height);
+        viewportState->scissors[0].extent.width -= 150;
 
         auto secondary_camera = vsg::Camera::create(projectionMatrix, viewMatrix, viewportState);
 


### PR DESCRIPTION
The overlay views are partially off the screen. The initial rendering is good, but the model snaps to the scissors of the overlays when the window is resized. This is because the viewport gets set to the scissor in the viewportstate. It was expected that the viewport and the scissor remain independent and should be resized individually.

initial view (expected):

![image](https://github.com/user-attachments/assets/f96edfcf-5453-4728-92c0-6e8244f2bae8)


view after a window resize (the models should not be snapped to the scissors of the overlay views):

![image](https://github.com/user-attachments/assets/5c55194d-bbe1-458b-846a-211bc33de295)

