### PR TITLE
Extend shader compiler define syntax to allow name=value instead of just valueless defines

### DIFF
--- a/examples/state/vsgclip/vsgclip.cpp
+++ b/examples/state/vsgclip/vsgclip.cpp
@@ -130,6 +130,13 @@ int main(int argc, char** argv)
 
         auto numFrames = arguments.value(-1, "-f");
 
+        auto numClips = arguments.value(1, "-n");
+        if (numClips < 1 || numClips > 2)
+        {
+            std::cout << "Choose between 1 and 2 clips. The first is a sphere the second is the X plane." << std::endl;
+            return 1;
+        }
+
         if (arguments.errors()) return arguments.writeErrorMessages(std::cerr);
 
         if (argc <= 1)
@@ -159,6 +166,10 @@ int main(int argc, char** argv)
             std::cout << "Please set VSG_FILE_PATH environmental variable to your vsgExamples/data directory." << std::endl;
             return 1;
         }
+
+        // specify the number of clips to perform; gl_ClipDistance array is sized by NUM_CLIPS
+        vertexShader->module->hints = vsg::ShaderCompileSettings::create();
+        vertexShader->module->hints->defines.insert("NUM_CLIPS="+std::to_string(numClips));
 
         // create the viewer and assign window(s) to it
         auto viewer = vsg::Viewer::create();


### PR DESCRIPTION
This pull request supports issue 1534 in VulkanSceneGraph and is a companion with VulkanSceneGraph Pull Request 1539.

The change is to the vsgclip example. It adds a command line option `-n` which takes an integer of either 1 or 2 indicating how many clips are desired. If not specified 1 is the default and the example behaves the same as before, clipping using a sphere in eye coordinates. If you specify 2 the example adds another clip on the X plane in world coordinates at X=0. The gl_ClipDistance array is dimensioned by the shader compiler define.