### PR TITLE
Improve vsggroups shared_ptr tests

### DIFF
--- a/examples/nodes/vsggroups/SharedPtrNode.cpp
+++ b/examples/nodes/vsggroups/SharedPtrNode.cpp
@@ -11,6 +11,15 @@ namespace experimental
     {
     }
 
+    void SharedPtrGroup::accept(SharedPtrVisitor& spv)
+    {
+        spv.apply(*this);
+    }
+    void SharedPtrGroup::traverse(SharedPtrVisitor& spv)
+    {
+        for (const auto& child : _children) child->accept(spv);
+    }
+
     void SharedPtrQuadGroup::accept(SharedPtrVisitor& spv)
     {
         spv.apply(*this);

--- a/examples/nodes/vsggroups/SharedPtrNode.h
+++ b/examples/nodes/vsggroups/SharedPtrNode.h
@@ -2,6 +2,9 @@
 
 #include <array>
 #include <memory>
+#include <vector>
+
+#include <vsg/core/Allocator.h>
 
 namespace experimental
 {
@@ -31,13 +34,38 @@ namespace experimental
         std::shared_ptr<SharedPtrAuxiliary> _auxiliary;
     };
 
+    class SharedPtrGroup;
     class SharedPtrQuadGroup;
 
     class SharedPtrVisitor
     {
     public:
         virtual void apply(SharedPtrNode&) {}
+        virtual void apply(SharedPtrGroup&) {}
         virtual void apply(SharedPtrQuadGroup&) {}
+    };
+
+    class SharedPtrGroup : public SharedPtrNode
+    {
+    public:
+        SharedPtrGroup() {}
+        SharedPtrGroup(size_t size) :
+            _children(size, nullptr)
+        {}
+
+        virtual void accept(SharedPtrVisitor& spv);
+        virtual void traverse(SharedPtrVisitor& spv);
+
+        using Children = std::vector<std::shared_ptr<SharedPtrNode>, vsg::allocator_affinity_nodes<std::shared_ptr<SharedPtrNode>>>;
+
+        void setChild(std::size_t i, std::shared_ptr<SharedPtrNode> node) { _children[i] = node; }
+        SharedPtrNode* getChild(std::size_t i) { return _children[i].get(); }
+        const SharedPtrNode* getChild(std::size_t i) const { return _children[i].get(); }
+
+        virtual ~SharedPtrGroup() {}
+
+    protected:
+        Children _children;
     };
 
     class SharedPtrQuadGroup : public SharedPtrNode

--- a/examples/nodes/vsggroups/vsggroups.cpp
+++ b/examples/nodes/vsggroups/vsggroups.cpp
@@ -97,6 +97,13 @@ public:
         object.traverse(*this);
     }
 
+    void apply(experimental::SharedPtrGroup& group) final
+    {
+        //std::cout<<"ExperimentVisitor::apply(vsg::SharedPtrGroup&)"<<std::endl;
+        ++numNodes;
+        group.traverse(*this);
+    }
+
     void apply(experimental::SharedPtrQuadGroup& group) final
     {
         //std::cout<<"ExperimentVisitor::apply(vsg::SharedPtrQuadGroup&)"<<std::endl;
@@ -162,20 +169,45 @@ std::shared_ptr<experimental::SharedPtrNode> createSharedPtrQuadTree(uint64_t nu
         numNodes += 1;
         numBytes += sizeof(experimental::SharedPtrNode);
 
-        return std::make_shared<experimental::SharedPtrNode>();
+        return std::allocate_shared<experimental::SharedPtrNode>(vsg::allocator_affinity_nodes<experimental::SharedPtrNode>());
     }
 
-    std::shared_ptr<experimental::SharedPtrQuadGroup> t = std::make_shared<experimental::SharedPtrQuadGroup>();
+    std::shared_ptr<experimental::SharedPtrGroup> t = std::allocate_shared<experimental::SharedPtrGroup>(vsg::allocator_affinity_nodes<experimental::SharedPtrNode>(), 4);
+
+    --numLevels;
+
+    numNodes += 1;
+    numBytes += sizeof(experimental::SharedPtrGroup);
+
+    t->setChild(0, createSharedPtrQuadTree(numLevels, numNodes, numBytes));
+    t->setChild(1, createSharedPtrQuadTree(numLevels, numNodes, numBytes));
+    t->setChild(2, createSharedPtrQuadTree(numLevels, numNodes, numBytes));
+    t->setChild(3, createSharedPtrQuadTree(numLevels, numNodes, numBytes));
+
+    return t;
+}
+
+std::shared_ptr<experimental::SharedPtrNode> createSharedPtrFixedQuadTree(uint64_t numLevels, uint64_t& numNodes, uint64_t& numBytes)
+{
+    if (numLevels == 0)
+    {
+        numNodes += 1;
+        numBytes += sizeof(experimental::SharedPtrNode);
+
+        return std::allocate_shared<experimental::SharedPtrNode>(vsg::allocator_affinity_nodes<experimental::SharedPtrNode>());
+    }
+
+    std::shared_ptr<experimental::SharedPtrQuadGroup> t = std::allocate_shared<experimental::SharedPtrQuadGroup>(vsg::allocator_affinity_nodes<experimental::SharedPtrNode>());
 
     --numLevels;
 
     numNodes += 1;
     numBytes += sizeof(experimental::SharedPtrQuadGroup);
 
-    t->setChild(0, createSharedPtrQuadTree(numLevels, numNodes, numBytes));
-    t->setChild(1, createSharedPtrQuadTree(numLevels, numNodes, numBytes));
-    t->setChild(2, createSharedPtrQuadTree(numLevels, numNodes, numBytes));
-    t->setChild(3, createSharedPtrQuadTree(numLevels, numNodes, numBytes));
+    t->setChild(0, createSharedPtrFixedQuadTree(numLevels, numNodes, numBytes));
+    t->setChild(1, createSharedPtrFixedQuadTree(numLevels, numNodes, numBytes));
+    t->setChild(2, createSharedPtrFixedQuadTree(numLevels, numNodes, numBytes));
+    t->setChild(3, createSharedPtrFixedQuadTree(numLevels, numNodes, numBytes));
 
     return t;
 }
@@ -289,6 +321,7 @@ int main(int argc, char** argv)
         if (type == "vsg::Group") vsg_root = createVsgQuadTree(numLevels, numNodes, numBytes);
         if (type == "vsg::QuadGroup") vsg_root = createFixedQuadTree(numLevels, numNodes, numBytes);
         if (type == "SharedPtrGroup") shared_root = createSharedPtrQuadTree(numLevels, numNodes, numBytes)->shared_from_this();
+        if (type == "SharedPtrQuadGroup") shared_root = createSharedPtrFixedQuadTree(numLevels, numNodes, numBytes)->shared_from_this();
     }
 
     if (!vsg_root && !shared_root)


### PR DESCRIPTION
Make tests more like-for-like with the ref_ptr ones by:
* using the VSG allocator
* adding `SharedPtrGroup` as a more direct equivalent to `vsg::Group`
* making the existing `SharedPtrQuadGroup` test more obviously equivalent to the `vsg::QuadGroup` test

This should make it less likely that anyone gets results that appear to suggest `ref_ptr` is no faster on their hardware. 